### PR TITLE
Fix authentication check to only verify github.com

### DIFF
--- a/gh-workflow-peek
+++ b/gh-workflow-peek
@@ -47,9 +47,9 @@ check_dependencies() {
         exit 1
     fi
     
-    # Check if gh is authenticated
-    if ! gh auth status &> /dev/null; then
-        echo "Error: GitHub CLI is not authenticated." >&2
+    # Check if gh is authenticated to github.com
+    if ! gh auth status -h github.com &> /dev/null; then
+        echo "Error: GitHub CLI is not authenticated to github.com." >&2
         echo "Please run 'gh auth login' first." >&2
         exit 1
     fi


### PR DESCRIPTION
## Summary
- Fixed authentication check in `gh-workflow-peek` script to specifically verify github.com authentication
- Prevents script from failing when other GitHub instances (e.g., corporate) have auth issues
- Changes `gh auth status` to `gh auth status -h github.com` to isolate the check

## Test plan
- [x] Verify script works with github.com authenticated but corporate GitHub instance failing
- [ ] Test script still properly detects when github.com is not authenticated
- [ ] Confirm all other functionality remains unchanged

🤖 Generated with [Claude Code](https://claude.ai/code)