### PR TITLE
Fix job array conversion hanging issue

### DIFF
--- a/gh-workflow-peek
+++ b/gh-workflow-peek
@@ -269,7 +269,10 @@ if [[ -z "$FAILED_JOBS" ]]; then
 fi
 
 # Convert to arrays
-IFS=$'\n' read -r -d '' -a FAILED_JOB_ARRAY <<< "$FAILED_JOBS"
+FAILED_JOB_ARRAY=()
+while IFS= read -r line; do
+    FAILED_JOB_ARRAY+=("$line")
+done <<< "$FAILED_JOBS"
 
 # Display failed jobs
 echo -e "\n${BOLD}Failed Jobs:${NC}"


### PR DESCRIPTION
## Summary
- Fixed an issue where the script would hang when converting failed jobs to an array
- Replaced the problematic `read -r -d '' -a` command with a robust while loop
- The script now properly handles multiline input without hanging

## Problem
When running `gh workflow-peek` on certain repositories (like scriptrag), the script would hang after displaying "Fetching jobs for run..." and never show any output. The issue was caused by the array conversion command at line 272:

```bash
IFS=$'\n' read -r -d '' -a FAILED_JOB_ARRAY <<< "$FAILED_JOBS"
```

This command with `-d ''` (empty delimiter) can cause the read command to hang in certain shell environments.

## Solution
Replaced the problematic command with a more robust approach:

```bash
FAILED_JOB_ARRAY=()
while IFS= read -r line; do
    FAILED_JOB_ARRAY+=("$line")
done <<< "$FAILED_JOBS"
```

This approach properly reads each line into the array without hanging.

## Test plan
- [x] Tested with `gh workflow-peek 16607967879 --repo trieloff/scriptrag --max 20`
- [x] Verified the script now displays failed jobs and logs correctly
- [x] Confirmed the script completes without hanging

🤖 Generated with [Claude Code](https://claude.ai/code)