### PR TITLE
Fix error when all PR checks are passing

### DIFF
--- a/gh-workflow-peek
+++ b/gh-workflow-peek
@@ -225,8 +225,22 @@ if [[ -z "$RUN_ID" ]]; then
                     exec "$0" "$FIRST_RUN_ID" --max 20 "${@:+$@}"
                 fi
             fi
+        else
+            # Check if there are any PR checks at all
+            ALL_CHECKS=$(echo "$PR_CHECKS_JSON" | jq -r '.[] | "\(.name)\t\(.state)"' | head -5)
+            if [[ -n "$ALL_CHECKS" ]]; then
+                echo -e "${BOLD}✅ All PR checks are passing!${NC}"
+                echo ""
+                echo "$ALL_CHECKS" | column -t -s $'\t'
+                echo ""
+                echo "No errors to peek. Great job!"
+                exit 0
+            fi
         fi
-    else
+    fi
+    
+    # If we reach here, either no PR checks exist or we couldn't find failed ones
+    if [[ -z "$PR_CHECKS_JSON" ]] || [[ $(echo "$PR_CHECKS_JSON" | jq '. | length') -eq 0 ]]; then
         # Fallback to recent failed runs
         echo -e "${BOLD}No PR checks found. Recent failed workflow runs:${NC}"
 


### PR DESCRIPTION
## Summary
- Fixed script error when PR has all passing checks
- Added friendly success message when no errors to peek

## Problem
When running `gh-workflow-peek` on a PR where all checks are passing, the script would error out or behave unexpectedly because it didn't handle the case where PR checks exist but none are in FAILURE or PENDING state.

## Solution
Added logic to detect when all PR checks are passing and display:
- A success message with checkmark emoji
- List of all passing checks
- Friendly "No errors to peek. Great job!" message
- Clean exit with status 0

## Test plan
- [x] Verified shellcheck passes
- [x] Tested filter logic with sample JSON data
- [ ] CI should pass on this PR
- [ ] After merge, running `gh-workflow-peek` on a PR with all green checks should show success message

🤖 Generated with [Claude Code](https://claude.ai/code)